### PR TITLE
Update EditorExtensionsRedux.cs

### DIFF
--- a/EditorExtensionsRedux/EditorExtensionsRedux.cs
+++ b/EditorExtensionsRedux/EditorExtensionsRedux.cs
@@ -489,7 +489,7 @@ namespace EditorExtensionsRedux
 
 				// H - Horizontally align part under cursor with the part it is attached to
 				if (Input.GetKeyDown (cfg.KeyMap.HorizontalSnap)) {
-					HorizontalAlign ();
+					HorizontalAlign (fineKeyDown);
 					return;
 				}     
 
@@ -847,11 +847,16 @@ namespace EditorExtensionsRedux
 			throw new NotImplementedException ();
 		}
 
-		void CenterHorizontallyOnParent (Part p)
+		void CenterHorizontallyOnParent (Part p, bool otherHorizontal = false)
 		{
-			p.transform.localPosition = new Vector3 (p.transform.localPosition.x, p.transform.localPosition.y, 0f);
-			p.attPos0.z = 0f;
-		}
+            if (otherHorizontal) {
+                p.transform.localPosition = new Vector3(0f, p.transform.localPosition.y, p.transform.localPosition.z);
+                p.attPos0.x = 0f;
+            } else {
+                p.transform.localPosition = new Vector3(p.transform.localPosition.x, p.transform.localPosition.y, 0f);
+                p.attPos0.z = 0f;
+            }
+        }
 
 		void VerticalAlign ()
 		{
@@ -877,7 +882,7 @@ namespace EditorExtensionsRedux
 			return;
 		}
 
-		void HorizontalAlign ()
+		void HorizontalAlign (bool otherHorizontal = false)
 		{
 			try {
 				Part sp = Utility.GetPartUnderCursor ();
@@ -890,11 +895,11 @@ namespace EditorExtensionsRedux
 					Log.Debug ("symmetryCounterparts to move: " + symParts.Count.ToString ());
 
 					//move selected part
-					CenterHorizontallyOnParent (sp);
+					CenterHorizontallyOnParent (sp, otherHorizontal);
 
 					//move any symmetry siblings/counterparts
 					foreach (Part symPart in symParts) {
-						CenterHorizontallyOnParent (symPart);
+						CenterHorizontallyOnParent (symPart, otherHorizontal);
 					}
 
 					//Add edit to undo history


### PR DESCRIPTION
Extension to "horizontally center" functionality where shift+H centers on z-axis.
Unfortunately mod+H is already is already taken by HyperEdit.
